### PR TITLE
Smaller font size for smaller screens

### DIFF
--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -13,6 +13,7 @@
     @include heading-font;
   }
   .navbar-brand {
+    font-size: 1.1em;
     color: $white;
     &.active,
     &:active,

--- a/_sass/layout/_masthead.scss
+++ b/_sass/layout/_masthead.scss
@@ -18,7 +18,7 @@ header.masthead {
       @include serif-font;
     }
     .intro-heading {
-      font-size: 50px;
+      font-size: 44px;
       font-weight: 700;
       line-height: 50px;
       margin-bottom: 25px;

--- a/_sass/layout/_portfolio.scss
+++ b/_sass/layout/_portfolio.scss
@@ -78,7 +78,7 @@
   .modal-content {
     padding: 100px 0;
     h2 {
-      font-size: 3em;
+      font-size: 1.4em;
       margin-bottom: 15px;
     }
     p {
@@ -141,6 +141,16 @@
         -ms-transform: rotate(90deg);
         transform: rotate(90deg);
         background-color: $gray-900;
+      }
+    }
+  }
+}
+
+@media (min-width: 768px) {
+  .portfolio-modal {
+    .modal-content {
+      h2 {
+        font-size: 2.2em;
       }
     }
   }


### PR DESCRIPTION
On my mobile (Huawei P20) headlines / texts were not fully visible on the screen. This is improved now (for "Zukunftsentscheid" this is not yet the case, maybe there we'd need a more elaborated solution).