### PR TITLE
Fix browser navigation for nav items

### DIFF
--- a/_data/_services/organisation.md
+++ b/_data/_services/organisation.md
@@ -1,5 +1,6 @@
 E4F Hamburg ist ein informeller Zusammenschluss von Menschen. Wir sind offen für alle – unabhängig von Branche, Bereich oder Hierarchie-Ebene. Unterstützer\*innen und Interessent\*innen können sich und ihre Themen gleichberechtigt einbringen.
 
-Treffen kündigen wir [hier](#portfolio) und über [Meetup](https://www.meetup.com/de-DE/entrepreneurs-for-future-hamburg/) an. Meldet euch gerne dort an, um informiert zu sein. Folgt uns auf LinkedIn und Twitter für weitere Infos.
+Treffen kündigen wir <a class="js-scroll-trigger" href="/#portfolio">hier</a> und über [Meetup](https://www.meetup.com/de-DE/entrepreneurs-for-future-hamburg/) an. Meldet euch gerne dort an, um informiert zu sein. Folgt uns auf LinkedIn und Twitter für weitere Infos.
 
-Orga-Treffen finden regelmäßig 14-tägig statt. Wenn ihr da mal reinschnuppern wollt, [kontaktiert](#contact) uns gern.
+Orga-Treffen finden regelmäßig 14-tägig statt. Wenn ihr da mal reinschnuppern wollt,
+<a class="js-scroll-trigger" href="/#contact">kontaktiert</a> uns gern.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,6 +24,7 @@
 	  <script src="assets/js/agency.min.js"></script>
 
 	  <!-- Custom script for modals -->
+	  <script src="assets/js/jquery.smooth-scroll.js"></script>
 	  <script src="assets/js/modals.js"></script>
 
   </body>

--- a/assets/js/modals.js
+++ b/assets/js/modals.js
@@ -44,12 +44,16 @@
             return;
         }
 
+        if (e.originalEvent === undefined) {
+            return;
+        }
+
         // get location hash from previous page
         let previousHash = e.originalEvent.oldURL.split("#")[1];
         // get location hash from current page
         let currentHash = e.originalEvent.newURL.split("#")[1];
         // if the previous page was a modal, and the current page is not a modal, hide the modal
-        if (previousHash && previousHash?.startsWith("event-")) {
+        if (previousHash && previousHash.startsWith("event-")) {
             ignoreEvent = "hidden.bs.modal";
             $('#' + previousHash).modal('toggle');
         }
@@ -58,5 +62,26 @@
             $('#' + currentHash).modal('toggle');
         }
     });
+
+    $('a[href*="#"]').bind('click', function(event) {
+        if (this.hash.startsWith("#event-")) {
+            return;
+        }
+        // Remove '#' from the hash.
+        var hash = this.hash.replace(/^#/, '');
+        if (this.pathname === location.pathname && hash) {
+            event.preventDefault();
+            // Change '#' (removed above) to '#/' so it doesn't jump without the smooth scrolling
+            location.hash = '#/' + hash;
+        }
+    });
+
+    // Scroll on page load if there is a hash in the URL.
+    if (location.hash && !location.hash.startsWith("#event-")) {
+        $.smoothScroll({
+            // Replace '#/' with '#' to go to the correct target
+            scrollTarget: location.hash.replace(/^\#\/?/, '#')
+        });
+    }
 
 })(jQuery);


### PR DESCRIPTION
This was partly broken before introducing bookmarkable urls for events, and with that got more visible. E.g. this was now unexpected behavior:
* Open https://e4f-hamburg.de/#event-06-12-23-e4f-vernetzungstreffen
* Close the event / modal dialog
* Click on "Kontakt"
  * scrolls as expected, but doesn't change the url hash (bug)
* Click browser back
  * this now opens the event / modal dialog again (unexpected - caused by the previous issue, that clicking on "Kontakt" didn't change the url

This fix is now based on
https://github.com/kswedberg/jquery-smooth-scroll?tab=readme-ov-file#fnsmoothscroll and the mentioned back button support as shown in https://github.com/kswedberg/jquery-smooth-scroll/blob/master/demo/hashchange.html

The same issue is described in
https://github.com/mmistakes/minimal-mistakes/issues/1767, which is related because our agency plugin also uses smooth scrolling.

The links in organisation.md are now html links so that navigation works again.